### PR TITLE
fix: Cloud Storage Badge Shown in Question Manager Without Login #27

### DIFF
--- a/src/app/question-manager/page.tsx
+++ b/src/app/question-manager/page.tsx
@@ -147,6 +147,7 @@ export default function QuestionManager() {
   const [filterDifficulty, setFilterDifficulty] = useState<string>('all');
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [editingQuestion, setEditingQuestion] = useState<any | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const { toast } = useToast();
 
   // Form state
@@ -165,6 +166,28 @@ export default function QuestionManager() {
     explanation: '',
     formula: '',
   });
+
+  // Check authentication status
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        setIsAuthenticated(!!session);
+      } catch (error) {
+        console.error('Error checking authentication:', error);
+        setIsAuthenticated(false);
+      }
+    };
+
+    checkAuth();
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((session) => {
+      setIsAuthenticated(!!session);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
 
   // Load subjects and questions
   useEffect(() => {
@@ -713,9 +736,13 @@ export default function QuestionManager() {
                 <div className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">
                   BTK Demo
                 </div>
-              ) : (
+              ) : isAuthenticated ? (
                 <div className="px-3 py-1 bg-green-100 text-green-800 rounded-full text-xs font-medium">
                   ☁️ Cloud Storage
+                </div>
+              ) : (
+                <div className="px-3 py-1 bg-gray-100 text-gray-800 rounded-full text-xs font-medium">
+                  💾 LocalStorage
                 </div>
               )}
             </div>


### PR DESCRIPTION
### **User description**
- Add authentication state management to Question Manager
- Show Cloud Storage badge only for authenticated users
- Show LocalStorage badge for unauthenticated users
- Maintain BTK Demo badge for demo mode
- Fix authentication state change listener parameter
- Closed #27


___

### **PR Type**
Bug fix


___

### **Description**
- Add authentication state management to Question Manager

- Show appropriate storage badges based on user authentication

- Fix Cloud Storage badge visibility for unauthenticated users

- Add LocalStorage badge for non-authenticated users


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Authentication Check"] --> B["Demo Mode?"]
  B -->|Yes| C["BTK Demo Badge"]
  B -->|No| D["Authenticated?"]
  D -->|Yes| E["Cloud Storage Badge"]
  D -->|No| F["LocalStorage Badge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add authentication-based storage badge display logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/question-manager/page.tsx

<ul><li>Add <code>isAuthenticated</code> state variable for tracking user authentication<br> <li> Implement authentication check with session validation and state <br>change listener<br> <li> Update badge rendering logic to show appropriate storage type based on <br>authentication<br> <li> Add LocalStorage badge for unauthenticated users</ul>


</details>


  </td>
  <td><a href="https://github.com/melihcanndemir/akilhane/pull/56/files#diff-b9d5a81b348d9b1aa845b3a9724af181ad5697593df15d36c8a335f0041aa80b">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

